### PR TITLE
Integrate OpenTelemetry java agent

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - 'main'
-      - 'epic/**'
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'master'
       - 'main'
+      - 'epic/**'
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
-Данный репозиторий содержит шаблоны (используемых в сервисах домена) ресурсов
+# shared-resources
 
-#Переопределяемые настройки `logback`
+Данный репозиторий содержит шаблоны ресурсов, используемых в сервисах домена.
 
-`application.yml`
+## Переопределяемые настройки `logback`
+
+`application.yml`:
+
 ```yaml
 logback:
   appender: JSON_K8S_CONSOLE # возможные значения: DEFAULT_CONSOLE || COLOR_CONSOLE || JSON_K8S_CONSOLE
 ```
 
-#`pom.xml`
+## Настройка `pom.xml`
+
+Dependency:
+
 ```xml
 <dependency>
     <groupId>dev.vality</groupId>
@@ -16,6 +22,9 @@ logback:
     <version>${shared.resources.version}</version>
 </dependency>
 ```
+
+Resources:
+
 ```xml
 <resources>
     <resource>
@@ -31,6 +40,7 @@ logback:
         <filtering>true</filtering>
         <excludes>
             <exclude>Dockerfile</exclude>
+            <exclude>opentelemetry-javaagent.jar</exclude>
         </excludes>
     </resource>
     <resource>
@@ -39,6 +49,9 @@ logback:
     </resource>
 </resources>
 ```
+
+Plugin:
+
 ```xml
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
@@ -67,3 +80,13 @@ logback:
     </executions>
 </plugin>
 ```
+
+## Отключение OpenTelemetry Java Agent
+
+Для отключения Java agent используйте один из вариантов:
+
+- Переменная окружения: `OTEL_JAVAAGENT_ENABLED=false`
+- JVM-параметр: `-Dotel.javaagent.enabled=false`
+
+Документация:
+[Disabling the agent entirely](https://opentelemetry.io/docs/zero-code/java/agent/disable/#disabling-the-agent-entirely)

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>shared-resources</artifactId>
-    <version>4.0.0-test-SNAPSHOT</version>
+    <version>4.0.0-alpha1</version>
     <packaging>jar</packaging>
 
     <name>Java shared resources</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>shared-resources</artifactId>
-    <version>4.1.0-alpha1</version>
+    <version>4.1.0</version>
     <packaging>jar</packaging>
 
     <name>Java shared resources</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>shared-resources</artifactId>
-    <version>4.0.0-alpha2</version>
+    <version>4.0.0-alpha1</version>
     <packaging>jar</packaging>
 
     <name>Java shared resources</name>
@@ -81,7 +81,7 @@
                 <executions>
                     <execution>
                         <id>copy-opentelemetry-javaagent</id>
-                        <phase>generate-resources</phase>
+                        <phase>process-resources</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>
@@ -93,7 +93,7 @@
                                     <version>${opentelemetry.javaagent.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.basedir}/src/main/resources</outputDirectory>
+                                    <outputDirectory>${project.build.directory}/classes</outputDirectory>
                                     <destFileName>opentelemetry-javaagent.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>shared-resources</artifactId>
-    <version>3.0.1</version>
+    <version>4.0.0-test-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Java shared resources</name>
@@ -38,6 +38,10 @@
         <url>https://github.com/valitydev/java-shared-resources/tree/master</url>
     </scm>
 
+    <properties>
+        <opentelemetry.javaagent.version>2.22.0</opentelemetry.javaagent.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -55,10 +59,48 @@
             <artifactId>janino</artifactId>
             <version>3.1.9</version>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.javaagent</groupId>
+            <artifactId>opentelemetry-javaagent</artifactId>
+            <version>${opentelemetry.javaagent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-logback-mdc-1.0</artifactId>
+            <version>2.22.0-alpha</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-opentelemetry-javaagent</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry.javaagent.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                                    <destFileName>opentelemetry-javaagent.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-remote-resources-plugin</artifactId>
                 <version>3.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>shared-resources</artifactId>
-    <version>4.0.0-alpha1</version>
+    <version>4.0.0-alpha2</version>
     <packaging>jar</packaging>
 
     <name>Java shared resources</name>
@@ -81,7 +81,7 @@
                 <executions>
                     <execution>
                         <id>copy-opentelemetry-javaagent</id>
-                        <phase>process-resources</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>
@@ -93,7 +93,7 @@
                                     <version>${opentelemetry.javaagent.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                                    <outputDirectory>${project.basedir}/src/main/resources</outputDirectory>
                                     <destFileName>opentelemetry-javaagent.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-logback-mdc-1.0</artifactId>
-            <version>2.26.1-alpha</version>
+            <version>${opentelemetry.javaagent.version}-alpha</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>shared-resources</artifactId>
-    <version>4.0.0-alpha3</version>
+    <version>4.0.0-alpha4</version>
     <packaging>jar</packaging>
 
     <name>Java shared resources</name>
@@ -80,8 +80,8 @@
                 <version>3.6.1</version>
                 <executions>
                     <execution>
-                        <id>copy-opentelemetry-javaagent</id>
-                        <phase>process-resources</phase>
+                        <id>copy-opentelemetry-javaagent-to-resources</id>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>
@@ -93,7 +93,7 @@
                                     <version>${opentelemetry.javaagent.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                                    <outputDirectory>${project.basedir}/src/main/resources</outputDirectory>
                                     <destFileName>opentelemetry-javaagent.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.vality</groupId>
         <artifactId>library-parent-pom</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>shared-resources</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>shared-resources</artifactId>
-    <version>4.0.0-alpha1</version>
+    <version>4.0.0-alpha3</version>
     <packaging>jar</packaging>
 
     <name>Java shared resources</name>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     </scm>
 
     <properties>
-        <opentelemetry.javaagent.version>2.22.0</opentelemetry.javaagent.version>
+        <opentelemetry.javaagent.version>2.26.1</opentelemetry.javaagent.version>
     </properties>
 
     <dependencies>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-logback-mdc-1.0</artifactId>
-            <version>2.22.0-alpha</version>
+            <version>2.26.1-alpha</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>shared-resources</artifactId>
-    <version>4.1.0</version>
+    <version>5.0.0</version>
     <packaging>jar</packaging>
 
     <name>Java shared resources</name>

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -2,11 +2,12 @@ FROM ghcr.io/valitydev/temurin-jemalloc:sha-14c0b34
 
 RUN useradd -s /bin/false -U -u 20000 vality
 
+COPY --chown=vality:vality opentelemetry-javaagent.jar /opt/${artifactId}/opentelemetry-javaagent.jar
 COPY --chown=vality:vality ${artifactId}-${version}.jar /opt/${artifactId}/${artifactId}.jar
 
 USER vality:vality
 
-CMD ["java", "-jar","/opt/${artifactId}/${artifactId}.jar"]
+CMD ["java", "-javaagent:/opt/${artifactId}/opentelemetry-javaagent.jar", "-jar","/opt/${artifactId}/${artifactId}.jar"]
 
 EXPOSE ${exposed.ports}
 

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/valitydev/temurin-jemalloc:sha-14c0b34
 
 RUN useradd -s /bin/false -U -u 20000 vality
 
-COPY --chown=vality:vality opentelemetry-javaagent.jar /opt/${artifactId}/opentelemetry-javaagent.jar
+COPY --chown=vality:vality maven-shared-archive-resources/opentelemetry-javaagent.jar /opt/${artifactId}/opentelemetry-javaagent.jar
 COPY --chown=vality:vality ${artifactId}-${version}.jar /opt/${artifactId}/${artifactId}.jar
 
 USER vality:vality

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -66,8 +66,17 @@
                 </encoder>
             </appender>
 
-            <root level="${loggingLevelRoot}">
+            <appender name="JSON_K8S_CONSOLE_OTEL"
+                      class="io.opentelemetry.instrumentation.logback.mdc.v1_0.OpenTelemetryAppender">
+                <addBaggage>true</addBaggage>
+                <traceIdKey>otel_trace_id</traceIdKey>
+                <spanIdKey>otel_span_id</spanIdKey>
+                <traceFlagsKey>otel_trace_flags</traceFlagsKey>
                 <appender-ref ref="JSON_K8S_CONSOLE"/>
+            </appender>
+
+            <root level="${loggingLevelRoot}">
+                <appender-ref ref="JSON_K8S_CONSOLE_OTEL"/>
             </root>
         </then>
     </if>


### PR DESCRIPTION
Интегрирован OpenTelemetry Java Agent в shared-resources, чтобы сервисы по умолчанию запускались с трассировкой и корреляцией логов